### PR TITLE
Improve track matching logic by adding support for hyphenated titles …

### DIFF
--- a/automated_console.py
+++ b/automated_console.py
@@ -3,7 +3,7 @@
 Replay Mix+ by soreikomori
 https://github.com/soreikomori/ReplayMixPlus
 """
-version = "1.6.0"
+version = "1.6.1"
 import pkg_resources
 import subprocess
 import sys

--- a/user_console.py
+++ b/user_console.py
@@ -3,7 +3,7 @@
 Replay Mix+ by soreikomori
 https://github.com/soreikomori/ReplayMixPlus
 """
-version = "1.6.0"
+version = "1.6.1"
 # PACKAGE CHECKER
 import subprocess
 import sys


### PR DESCRIPTION
# Version 1.6.1
## Enhancements
- Tracks now match if their title is hyphenated on the compendium. For example, if a track's title is "Track - Song", and in last.fm it is scrobbled as either "Track" or "Song", it will now match.